### PR TITLE
Fix: Show placeholder icon when item has no thumbnail

### DIFF
--- a/packages/mobile/components/List.tsx
+++ b/packages/mobile/components/List.tsx
@@ -406,7 +406,11 @@ function Thumbnail({ item, type }: { item: ChildItem; type: ThumbnailType }) {
     type == ThumbnailType.Poster ? styles.posterThumb : styles.videoThumb;
 
   if (!uri) {
-    return <View style={style} />;
+    return (
+      <View style={style}>
+        <MaterialIcons name="broken-image" size={Math.min(style.width, style.height) * 0.5} color="#999999" />
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
## Fix: Shows with no thumbnail appear as broken images

Closes #43

**Problem:** When an item has no thumbnail, the code returned an empty `<View style={style} />` — a transparent, invisible box. Users see this as a "broken image".

**Fix:** When `uri` is undefined (no thumbnail stored), render a `broken-image` MaterialIcons placeholder instead of an empty View.

```tsx
// Before
if (!uri) {
  return <View style={style} />;
}

// After
if (!uri) {
  return (
    <View style={style}>
      <MaterialIcons name="broken-image" size={Math.min(style.width, style.height) * 0.5} color="#999999" />
    </View>
  );
}
```
